### PR TITLE
fix: conftest cleanup now don't pick up abstract model classes class

### DIFF
--- a/cratedb_django/base.py
+++ b/cratedb_django/base.py
@@ -153,7 +153,9 @@ def aggressively_refresh():
                 table_name = match.group(1)
                 return args[0].execute(f"refresh table {table_name}", None)
             return func
+
         return wrapper
+
     return deco
 
 

--- a/cratedb_django/models/model.py
+++ b/cratedb_django/models/model.py
@@ -28,7 +28,8 @@ class MetaCrate(ModelBase):
 
         o = super().__new__(cls, name, bases, attrs, **kwargs)
 
-        # Return back the crate_attrs we took from meta to the already created object.
+        # Return back the crate_attrs we took from meta to the already
+        # created object.
         for k, v in crate_attrs.items():
             setattr(o._meta, k, v)
         return o

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,8 @@ def clean_database(request):
     ]
 
     for model in models:
-        if model._meta.app_label != "ignore":
+
+        if model._meta.app_label != "ignore" and not model._meta.abstract:
             with connection.cursor() as cursor:
                 cursor.execute(f"DELETE FROM {model._meta.db_table}")
                 cursor.execute(f"REFRESH TABLE {model._meta.db_table}")

--- a/tests/test_app/models.py
+++ b/tests/test_app/models.py
@@ -5,6 +5,11 @@ from django.db import models
 from cratedb_django.fields import ObjectField
 from cratedb_django.models import CrateModel
 
+"""
+We need to register the models here so they get correctly configured and
+detected by django.
+"""
+
 
 class AllFieldsModel(CrateModel):
     field_int = models.IntegerField(unique=False)
@@ -22,7 +27,7 @@ class AllFieldsModel(CrateModel):
     field_uuid = models.UUIDField()
 
     @classmethod
-    def create_test(cls):
+    def create_dummy(cls):
         return cls.objects.create(
             field_int=1,
             field_int_unique=2,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,7 +1,6 @@
-import pprint
+from tests.test_app.models import AllFieldsModel, SimpleModel, RefreshModel
 
 from django.forms.models import model_to_dict
-from tests.test_app.models import AllFieldsModel, SimpleModel, RefreshModel
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 
@@ -10,13 +9,16 @@ from tests.utils import captured_queries
 
 def test_model_refresh():
     """Test that Model.refresh() works"""
+    expected_query = "refresh table test_app_simplemodel"
     with CaptureQueriesContext(connection) as ctx:
         SimpleModel.refresh()
-        assert "refresh table test_app_simplemodel" in ctx.captured_queries[0]["sql"]
+        assert expected_query in ctx.captured_queries[0]["sql"]
 
 
 def test_model_refresh_meta():
-    """Test that a refresh statement is sent after updating or inserting when auto_refresh=True in Meta"""
+    """Test that a refresh statement is sent after updating
+    or inserting when auto_refresh=True in Meta"""
+
     with captured_queries(connection) as ctx:
         # Test insert
         RefreshModel.objects.create(field="sometext")
@@ -24,7 +26,8 @@ def test_model_refresh_meta():
 
 
 def test_model_auto_pk_value_exists():
-    """Test that when we create a model object with Django created 'id', the value gets added to the Object"""
+    """Test that when we create a model object with Django created
+    'id', the value gets added to the Object"""
     obj = SimpleModel.objects.create(field="test_model_auto_pk_value_exists")
     SimpleModel.refresh()
     assert obj.id
@@ -53,8 +56,6 @@ def test_update_model():
         obj.field = "sometext"
         obj.save()
 
-
-
         assert obj.field == "sometext"
         assert pk == obj.pk  # Pk did not change
 
@@ -63,6 +64,7 @@ def test_update_model():
         SimpleModel.refresh()
         # assert SimpleModel.objects.count() == 1
         # pprint.pp(ctx.captured_queries)
+
 
 def test_delete_from_model():
     with captured_queries(connection) as ctx:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Some tests could become flaky locally because base DjangoModel was being incorrectly picked up in tests cleanup.

Some other lint/minor tweaks were also included.