### PR TITLE
fix: Set default values when Model does not specify cratedb attributes.

### DIFF
--- a/cratedb_django/models/model.py
+++ b/cratedb_django/models/model.py
@@ -1,11 +1,15 @@
 from django.db import models, connection
 from django.db.models.base import ModelBase
 
-# Tuple of all the extra options a CrateModel Meta class has.
+# If a meta option has the value OMITTED, it will be omitted
+# from SQL creation.
+OMITTED = object()
+
+# dict of all the extra options a CrateModel Meta class has.
 # (name, default_value)
-CRATE_META_OPTIONS = (
-    ("auto_refresh", False),  # Automatically refresh a table on inserts.
-)
+CRATE_META_OPTIONS = {
+    "auto_refresh": False,  # Automatically refresh a table on inserts.
+}
 
 
 class MetaCrate(ModelBase):
@@ -16,12 +20,10 @@ class MetaCrate(ModelBase):
 
         try:
             meta = attrs["Meta"]
-            for crate_attr in CRATE_META_OPTIONS:
-                attr_name = crate_attr[0]
-                if hasattr(meta, attr_name):
-                    crate_attrs[attr_name] = meta.__dict__[attr_name]
-                    delattr(meta, attr_name)
-
+            for key, default_value in CRATE_META_OPTIONS.items():
+                crate_attrs[key] = getattr(meta, key, default_value)
+                if hasattr(meta, key):
+                    delattr(meta, key)
         except KeyError:
             # Has no meta class
             pass

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,3 +1,5 @@
+from cratedb_django.models import CrateModel
+from cratedb_django.models.model import CRATE_META_OPTIONS
 from tests.test_app.models import AllFieldsModel, SimpleModel, RefreshModel
 
 from django.forms.models import model_to_dict
@@ -106,3 +108,28 @@ def test_insert_all_fields():
 
     obj = AllFieldsModel.objects.get()
     assert model_to_dict(obj) == expected
+
+
+def test_model_meta():
+    """
+    Tests that default values are properly set even when not specified
+    """
+
+    class NoMetaOptions(CrateModel):
+        class Meta:
+            app_label = "ignore"
+
+    class RefreshMetaOptions(CrateModel):
+        class Meta:
+            app_label = "ignore"
+            auto_refresh = True
+
+    # Check all defaults are set.
+    for key, default_value in CRATE_META_OPTIONS.items():
+        assert key in NoMetaOptions._meta.__dict__
+        assert getattr(NoMetaOptions._meta, key) is default_value
+
+    # Check the combination of user-defined + default.
+    assert "auto_refresh" in RefreshMetaOptions._meta.__dict__
+    assert RefreshMetaOptions._meta.auto_refresh is True
+    # TODO Add the default part (currently we only support one option)


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Now the default values are correctly set

## Checklist

 - [x] Link to issue this PR refers to (if applicable): Fixes #17 
