### PR TITLE
Implement a base field for all django fields.

### DIFF
--- a/cratedb_django/fields/__init__.py
+++ b/cratedb_django/fields/__init__.py
@@ -1,3 +1,141 @@
-from .json import ObjectField
+from django.db.models import fields, JSONField
 
-__all__ = ["ObjectField"]
+from .base import CrateDBBaseField
+from .json import ObjectField
+from .array import ArrayField
+
+
+class AutoField(CrateDBBaseField, fields.AutoField):
+    pass
+
+
+class BigAutoField(CrateDBBaseField, fields.BigAutoField):
+    pass
+
+
+class BigIntegerField(CrateDBBaseField, fields.BigIntegerField):
+    pass
+
+
+class BinaryField(CrateDBBaseField, fields.BinaryField):
+    pass
+
+
+class BooleanField(CrateDBBaseField, fields.BooleanField):
+    pass
+
+
+class CharField(CrateDBBaseField, fields.CharField):
+    pass
+
+
+class DateField(CrateDBBaseField, fields.DateField):
+    pass
+
+
+class DateTimeField(CrateDBBaseField, fields.DateTimeField):
+    pass
+
+
+class DecimalField(CrateDBBaseField, fields.DecimalField):
+    pass
+
+
+class DurationField(CrateDBBaseField, fields.DurationField):
+    pass
+
+
+class EmailField(CrateDBBaseField, fields.EmailField):
+    pass
+
+
+class FloatField(CrateDBBaseField, fields.FloatField):
+    pass
+
+
+class GeneratedField(CrateDBBaseField, fields.FloatField):
+    pass
+
+
+class GenericIPAddressField(CrateDBBaseField, fields.GenericIPAddressField):
+    pass
+
+
+class IntegerField(CrateDBBaseField, fields.IntegerField):
+    pass
+
+
+class PositiveBigIntegerField(CrateDBBaseField, fields.PositiveBigIntegerField):
+    pass
+
+
+class PositiveIntegerField(CrateDBBaseField, fields.PositiveIntegerField):
+    pass
+
+
+class PositiveSmallIntegerField(CrateDBBaseField, fields.PositiveSmallIntegerField):
+    pass
+
+
+class SlugField(CrateDBBaseField, fields.SlugField):
+    pass
+
+
+class SmallAutoField(CrateDBBaseField, fields.SmallAutoField):
+    pass
+
+
+class SmallIntegerField(CrateDBBaseField, fields.SmallIntegerField):
+    pass
+
+
+class TextField(CrateDBBaseField, fields.TextField):
+    pass
+
+
+class TimeField(CrateDBBaseField, fields.TimeField):
+    pass
+
+
+class URLField(CrateDBBaseField, fields.URLField):
+    pass
+
+
+class JSONField(CrateDBBaseField, JSONField):
+    pass
+
+
+class UUIDField(CrateDBBaseField, fields.UUIDField):
+    pass
+
+
+__all__ = [
+    "ObjectField",
+    "ArrayField",
+    "AutoField",
+    "BigAutoField",
+    "BigIntegerField",
+    "BinaryField",
+    "BooleanField",
+    "CharField",
+    "DateField",
+    "DateTimeField",
+    "DecimalField",
+    "DurationField",
+    "EmailField",
+    "FloatField",
+    "GeneratedField",
+    "GenericIPAddressField",
+    "IntegerField",
+    "PositiveBigIntegerField",
+    "PositiveIntegerField",
+    "PositiveSmallIntegerField",
+    "SlugField",
+    "SmallAutoField",
+    "SmallIntegerField",
+    "TextField",
+    "TimeField",
+    "URLField",
+    "JSONField",
+    "UUIDField",
+]

--- a/cratedb_django/fields/array.py
+++ b/cratedb_django/fields/array.py
@@ -1,9 +1,14 @@
-from django.db.models import Field, CharField
+from django.db.models import Field
+from cratedb_django.fields import CrateDBBaseField
 
 
-class ArrayField(Field):
+class ArrayField(CrateDBBaseField):
+    """
+    An array-like field.
+    """
+
     def __init__(self, base_field: Field, **kwargs):
-        # The internal type, called like this to
+        # The internal type of the array, named like this to
         # be compatible with postgres driver.
         self.base_field = base_field
 

--- a/cratedb_django/fields/base.py
+++ b/cratedb_django/fields/base.py
@@ -1,0 +1,11 @@
+from django.db.models import Field
+
+
+class CrateDBBaseField(Field):
+    """
+    Base field for CrateDB columns, it implements crate specific
+    column options.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)

--- a/cratedb_django/fields/json.py
+++ b/cratedb_django/fields/json.py
@@ -1,4 +1,4 @@
-from django.db.models import JSONField
+from cratedb_django.fields import JSONField
 
 
 class ObjectField(JSONField):

--- a/tests/test_app/models.py
+++ b/tests/test_app/models.py
@@ -1,9 +1,7 @@
 import datetime, uuid
 
-from django.db import models
 
-from cratedb_django.fields import ObjectField
-from cratedb_django.fields.array import ArrayField
+from cratedb_django import fields
 from cratedb_django.models import CrateModel
 
 """
@@ -13,17 +11,17 @@ detected by django.
 
 
 class AllFieldsModel(CrateModel):
-    field_int = models.IntegerField(unique=False)
-    field_int_unique = models.IntegerField(unique=True)
-    field_int_not_indexed = models.IntegerField(db_index=False)
-    field_int_not_null = models.IntegerField(null=False)
-    field_int_null = models.IntegerField(null=True)
-    field_int_default = models.IntegerField(default=54321)
-    field_float = models.FloatField()
-    field_char = models.CharField(max_length=100)
-    field_bool = models.BooleanField()
-    field_json = ObjectField(default=dict)
-    field_uuid = models.UUIDField()
+    field_int = fields.IntegerField(unique=False)
+    field_int_unique = fields.IntegerField(unique=True)
+    field_int_not_indexed = fields.IntegerField(db_index=False)
+    field_int_not_null = fields.IntegerField(null=False)
+    field_int_null = fields.IntegerField(null=True)
+    field_int_default = fields.IntegerField(default=54321)
+    field_float = fields.FloatField()
+    field_char = fields.CharField(max_length=100)
+    field_bool = fields.BooleanField()
+    field_json = fields.ObjectField(default=dict)
+    field_uuid = fields.UUIDField()
 
     @classmethod
     def create_dummy(cls):
@@ -48,29 +46,31 @@ class AllFieldsModel(CrateModel):
 
 
 class ArraysModel(CrateModel):
-    field_int = ArrayField(base_field=models.IntegerField(), null=True)
-    field_int_not_null = ArrayField(models.IntegerField(), null=False, default=[])
-    field_int_default = ArrayField(models.IntegerField(), default=[123, 321])
-    field_float = ArrayField(models.FloatField())
-    field_char = ArrayField(models.CharField(max_length=100))
-    field_bool = ArrayField(models.BooleanField())
-    field_json = ArrayField(ObjectField())
-    field_uuid = ArrayField(models.UUIDField())
-    field_nested = ArrayField(ArrayField(models.CharField()))
+    field_int = fields.ArrayField(base_field=fields.IntegerField(), null=True)
+    field_int_not_null = fields.ArrayField(
+        fields.IntegerField(), null=False, default=[]
+    )
+    field_int_default = fields.ArrayField(fields.IntegerField(), default=[123, 321])
+    field_float = fields.ArrayField(fields.FloatField())
+    field_char = fields.ArrayField(fields.CharField(max_length=100))
+    field_bool = fields.ArrayField(fields.BooleanField())
+    field_json = fields.ArrayField(fields.ObjectField())
+    field_uuid = fields.ArrayField(fields.UUIDField())
+    field_nested = fields.ArrayField(fields.ArrayField(fields.CharField()))
 
     class Meta:
         app_label = "test_app"
 
 
 class SimpleModel(CrateModel):
-    field = models.TextField()
+    field = fields.TextField()
 
     class Meta:
         app_label = "test_app"
 
 
 class RefreshModel(CrateModel):
-    field = models.TextField()
+    field = fields.TextField()
 
     class Meta:
         app_label = "test_app"

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -3,10 +3,9 @@ import uuid
 from django.db import connection, models
 from django.forms.models import model_to_dict
 
-from cratedb_django.fields import ObjectField
-from cratedb_django.fields.array import ArrayField
-from cratedb_django.models import functions
+from cratedb_django import fields
 
+from cratedb_django.models import functions
 from tests.test_app.models import ArraysModel
 
 
@@ -16,7 +15,7 @@ def test_field_with_uuid_default():
     """
 
     class TestModel(models.Model):
-        f = models.TextField(db_default=functions.UUID())
+        f = fields.TextField(db_default=functions.UUID())
 
         class Meta:
             app_label = "_crate_test"
@@ -30,9 +29,9 @@ def test_field_with_uuid_default():
 
 def test_field_array_creation():
     class SomeModel(models.Model):
-        f1 = ArrayField(models.IntegerField())
-        f2 = ArrayField(ArrayField(models.CharField(max_length=120)))
-        f3 = ArrayField(ArrayField(ObjectField()))
+        f1 = fields.ArrayField(fields.IntegerField())
+        f2 = fields.ArrayField(fields.ArrayField(fields.CharField(max_length=120)))
+        f3 = fields.ArrayField(fields.ArrayField(fields.ObjectField()))
 
         class Meta:
             app_label = "_crate_test"
@@ -63,7 +62,7 @@ def test_field_array_deconstruct():
     """
 
     class SomeModel(models.Model):
-        f = ArrayField(models.CharField())
+        f = fields.ArrayField(fields.CharField())
 
         class Meta:
             app_label = "_crate_test"
@@ -73,7 +72,7 @@ def test_field_array_deconstruct():
     assert name == "f"
     assert args == []
     assert path == "cratedb_django.fields.array.ArrayField"
-    assert isinstance(kwargs["base_field"], models.CharField)
+    assert isinstance(kwargs["base_field"], fields.CharField)
 
 
 def test_field_array_insert():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,6 +2,7 @@ import pytest
 
 from cratedb_django.models import CrateModel
 from cratedb_django.models.model import CRATE_META_OPTIONS, OMITTED
+from cratedb_django import fields
 
 from django.forms.models import model_to_dict
 from django.db import connection, models
@@ -141,9 +142,9 @@ def test_model_meta_partition_by():
     """Test partition_by option in Meta class."""
 
     class MetaOptions(CrateModel):
-        one = models.TextField()
-        two = models.TextField()
-        three = models.TextField()
+        one = fields.TextField()
+        two = fields.TextField()
+        three = fields.TextField()
 
         class Meta:
             app_label = "_crate_test"
@@ -180,9 +181,9 @@ def test_array_field_creation():
     from cratedb_django.fields.array import ArrayField
 
     class SomeModel(models.Model):
-        f1 = ArrayField(models.IntegerField())
-        f2 = ArrayField(ArrayField(models.CharField(max_length=120)))
-        f3 = ArrayField(ArrayField(ObjectField()))
+        f1 = fields.ArrayField(fields.IntegerField())
+        f2 = fields.ArrayField(fields.ArrayField(fields.CharField(max_length=120)))
+        f3 = fields.ArrayField(fields.ArrayField(fields.ObjectField()))
 
         class Meta:
             app_label = "ignore"
@@ -213,7 +214,7 @@ def test_array_deconstruct():
     """
 
     class SomeModel(models.Model):
-        f = ArrayField(models.CharField())
+        f = fields.ArrayField(fields.CharField())
 
         class Meta:
             app_label = "ignore"
@@ -254,7 +255,7 @@ def test_model_custom_id():
     """
 
     class SomeModel(CrateModel):
-        id = models.TextField(primary_key=True)
+        id = fields.TextField(primary_key=True)
 
         class Meta:
             app_label = "_crate_test"
@@ -275,10 +276,10 @@ def test_clustered_by():
     """
 
     class MetaOptions(CrateModel):
-        id = models.IntegerField()
-        one = models.TextField()
-        two = models.TextField()
-        three = models.TextField()
+        id = fields.IntegerField()
+        one = fields.TextField()
+        two = fields.TextField()
+        three = fields.TextField()
 
         class Meta:
             app_label = "ignore"


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Implement a `CrateDBBaseField` to be the base of all the fields, this will allows us to support general column features directly to all fields, for example `index=off` or `column=off`.

## Checklist

 - [x] Link to issue this PR refers to (if applicable): Fixes #25 