### PR TITLE
feat: Add support for `AutoUUIDField`

### DIFF
--- a/cratedb_django/fields/__init__.py
+++ b/cratedb_django/fields/__init__.py
@@ -6,6 +6,7 @@ from django.db.models.fields.generated import GeneratedField
 from .base import CrateDBBaseField
 from .json import ObjectField
 from .array import ArrayField
+from .uuid import AutoUUIDField
 
 
 class AutoField(CrateDBBaseField, fields.AutoField):
@@ -165,4 +166,5 @@ __all__ = [
     "URLField",
     "JSONField",
     "UUIDField",
+    "AutoUUIDField",
 ]

--- a/cratedb_django/fields/uuid.py
+++ b/cratedb_django/fields/uuid.py
@@ -1,0 +1,29 @@
+from django.db.models import fields
+
+
+class AutoUUIDField(fields.AutoField):
+    """Auto field that uses the database uuid generation function."""
+
+    def __init__(self, **kwargs):
+        from cratedb_django.models import functions
+
+        kwargs |= {"db_default": functions.UUID()}
+        super().__init__(**kwargs)
+
+    def get_prep_value(self, value):
+        return value
+
+    def get_internal_type(self):
+        return "AutoUUIDField"
+
+    def db_type(self, connection):
+        """The column type"""
+        # The size of an elasticflake:
+        # $ select char_length(gen_random_text_uuid())
+        # 20
+        return "char(20)"
+
+    def get_default(self):
+        # This makes django ignore this column in inserts, since CrateDB does not support
+        # the DEFAULT keyword. https://github.com/crate/crate/issues/14575
+        return None

--- a/cratedb_django/models/functions.py
+++ b/cratedb_django/models/functions.py
@@ -2,12 +2,6 @@ from django.db.models.expressions import Func
 
 from cratedb_django.fields import TextField
 
-"""
-class SomeModel(CrateModel):
-    id = models.TextField(primary_key=True, db_default=UUID())
-    some = models.TextField()
-"""
-
 
 class UUID(Func):
     """https://cratedb.com/docs/crate/reference/en/latest/general/builtins/scalar-functions.html#gen-random-text-uuid"""

--- a/cratedb_django/operations.py
+++ b/cratedb_django/operations.py
@@ -3,6 +3,18 @@ from django.db.backends.base.operations import BaseDatabaseOperations
 
 class DatabaseOperations(BaseDatabaseOperations):
     compiler_module = "cratedb_django.compiler"
+    integer_field_ranges = {
+        "SmallIntegerField": (-32768, 32767),
+        "IntegerField": (-2147483648, 2147483647),
+        "BigIntegerField": (-9223372036854775808, 9223372036854775807),
+        "PositiveBigIntegerField": (0, 9223372036854775807),
+        "PositiveSmallIntegerField": (0, 32767),
+        "PositiveIntegerField": (0, 2147483647),
+        "SmallAutoField": (-32768, 32767),
+        "AutoField": (-2147483648, 2147483647),
+        "BigAutoField": (-9223372036854775808, 9223372036854775807),
+        "AutoUUIDField": (None, None),
+    }
 
     def quote_name(self, name) -> str:
         if name.startswith('"') and name.endswith('"'):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -48,4 +48,4 @@ TEMPLATES = [
     },
 ]
 
-DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+DEFAULT_AUTO_FIELD = "cratedb_django.fields.AutoUUIDField"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -38,7 +38,7 @@ def test_model_auto_pk_value_exists():
     assert obj.id
     assert obj.pk
     assert obj.id == obj.pk
-    assert isinstance(obj.id, int)
+    assert isinstance(obj.id, str)
 
 
 def test_insert_model_field():
@@ -89,7 +89,7 @@ def test_insert_all_fields():
     for with all supported field types"""
 
     expected = {
-        "id": 29147646,
+        "id": "FGFgS5sBCuFygwVIzRxt",
         "field_int": 1,
         "field_int_unique": 2,
         "field_int_not_indexed": 3,
@@ -191,7 +191,7 @@ def test_model_id():
         sql, params = schema_editor.column_sql(
             SomeModel, SomeModel._meta.get_field("id")
         )
-        assert sql == "bigint default (random() * 2^63-1)::bigint NOT NULL PRIMARY KEY"
+        assert sql == "char(20) DEFAULT (gen_random_text_uuid()) NOT NULL PRIMARY KEY"
 
 
 def test_model_custom_id():


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
This adds support for a database generated uuid auto field, the autofield in django expects the field to be an integer, therefore we patch where needed so it can be a string.

The main idea is that we use this auto field as the PK field for the automatically added field `id`

## Checklist

 - [x] Link to issue this PR refers to (if applicable): Fixes #46 